### PR TITLE
IDAM-Login Spike

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-	"editor.formatOnSave": true,
 	"editor.rulers": [],
 	"files.eol": "\n",
 	"sasslint.enable": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
 	"editor.formatOnSave": true,
-	"editor.rulers": [80],
+	"editor.rulers": [],
 	"files.eol": "\n",
 	"sasslint.enable": false,
 	"css.validate": false,

--- a/auth_config.json
+++ b/auth_config.json
@@ -1,0 +1,4 @@
+{
+  "domain": "dev-identity.nice.org.uk",
+  "clientId": "14x3y8clvgQZTVSuPJzMAibOxr5qyHvM"
+}

--- a/examples/body-html/identity-popup.body.html
+++ b/examples/body-html/identity-popup.body.html
@@ -1,0 +1,199 @@
+<link href="//fonts.googleapis.com/css?family=Lato:400,700,900" rel="stylesheet" type="text/css" />
+<link href="//cdn.nice.org.uk/niceorg/css/app.min.css" rel="stylesheet" type="text/css" />
+
+<script src="https://www.nice.org.uk/Themes/NICE.Bootstrap/scripts/jquery/jquery-1.12.4.min.js" type="text/javascript"></script>
+<script src="https://www.nice.org.uk/Themes/NICE.Bootstrap/scripts/head.combined-v1.10.7695.0.js" type="text/javascript"></script>
+
+
+
+<header class="container  ">
+	<div class="zone zone-breadcrumb">
+
+			<div class="widget-breadcrumb widget-html-widget widget">
+					<div class="widget-content">
+							<div class="hero">
+									<div class="hero__container">
+											<nav aria-label="Breadcrumbs">
+													<ol class="breadcrumbs" itemscope="" itemtype="http://schema.org/BreadcrumbList">
+															<li class="breadcrumbs__crumb" itemprop="itemListElement" itemscope="" itemtype="http://schema.org/ListItem"><a href="https://www.nice.org.uk/" itemprop="name"> Home </a></li>
+															<li class="breadcrumbs__crumb" itemprop="itemListElement" itemscope="" itemtype="http://schema.org/ListItem"><span itemprop="name"> NICE guidance </span></li>
+													</ol>
+											</nav>
+											<div class="hero__body">
+													<div class="hero__copy">
+															<h1 id="content-start" class="hero__title">NICE guidance</h1>
+															<p class="hero__intro">Evidence-based recommendations developed by independent committees, including professionals and lay members, and consulted on&nbsp;by&nbsp;stakeholders.</p>
+															<div class="hero__actions"><a href="/guidance/published?type=apg,csg,cg,mpg,ph,sg,sc,dg,hst,ipg,mtg,qs,ta" class="btn btn--cta">View all guidance</a></div>
+													</div>
+													<div class="hero__extra">
+															<h2 class="h3 mt--0-md">Popular in guidance</h2>
+															<ul class="list--unstyled list--loose">
+																	<li><a href="/guidance/conditions-and-diseases">Conditions and diseases topic&nbsp;pages</a></li>
+																	<li><a href="/guidance/lifestyle-and-wellbeing">Lifestyle and wellbeing topic&nbsp;pages</a></li>
+																	<li><a href="/guidance/lifestyle-and-wellbeing">NICE guidelines</a></li>
+																	<li><a href="/guidance/published?type=cg">Clinical guidelines</a></li>
+															</ul>
+													</div>
+											</div>
+											<section class="hero__footer" aria-labelledby="new-updated">
+													<h2 class="h5 mv--0 show--ib mr--d" id="new-updated">New&nbsp;and updated products:</h2>
+													<ul class="list list--piped show--ib">
+															<li><a href="/guidance/date"><span class="visually-hidden">New and updated products </span><span class="text-uppercase">t</span>his month</a></li>
+															<li><a href="/guidance/lastmonth"><span class="visually-hidden">New and updated products </span><span class="text-uppercase">l</span>ast month</a></li>
+															<li><a href="/guidance/last6months"><span class="visually-hidden">New and updated products in the </span><span class="text-uppercase">l</span>ast 6 months</a></li>
+													</ul>
+											</section>
+									</div>
+							</div>
+					</div>
+			</div>
+	</div>
+</header>
+<div id="toTop"><i aria-hidden="true" class="icon-nice-chevron-up"></i></div>
+<div class="layout ">
+	<div class="">
+			<div class="zone zone-content">
+					<div class="page-content corporate-content">
+							<div>
+									<main class="grid grid--loose">
+											<div data-g="12 md:4">
+													<div class="panel mt--0 mb--0-md">
+															<section aria-labelledby="topics">
+																	<h2 id="topics" class="mt--0">Browse by topic</h2>
+																	<p>Topic pages bring together products on the same subject, for example <a href="/guidance/conditions-and-diseases/diabetes-and-other-endocrinal--nutritional-and-metabolic-conditions/diabetes">diabetes</a>, <a href="/guidance/lifestyle-and-wellbeing/mental-health-and-wellbeing">mental health and wellbeing</a> or <a href="/guidance/population-groups/children-and-young-people">children and young&nbsp;people</a>.</p>
+																	<h3>Find a topic page by</h3>
+																	<ul class="list list--unstyled list--loose">
+																			<li><a href="/guidance/conditions-and-diseases">Conditions and diseases</a></li>
+																			<li><a href="/guidance/health-protection">Health protection</a></li>
+																			<li><a href="/guidance/lifestyle-and-wellbeing">Lifestyle and wellbeing</a></li>
+																			<li><a href="/guidance/population-groups">Population groups</a></li>
+																			<li><a href="/guidance/service-delivery--organisation-and-staffing">Service delivery, organisation and&nbsp;staffing</a></li>
+																			<li><a href="/guidance/settings">Settings</a></li>
+																	</ul>
+															</section>
+															<hr />
+															<section aria-labelledby="pathways">
+																	<h2 id="pathways">NICE Pathways</h2>
+																	<p>Integrated view of all NICE guidance and advice in topic based interactive&nbsp;flowcharts.</p>
+																	<p><a href="https://pathways.nice.org.uk/" class="show"> View all NICE Pathways <img src="https://www.nice.org.uk/Media/Default/images/topic-pages/pathways-example.png" alt="" class="show" /> </a></p>
+															</section>
+													</div>
+											</div>
+											<div data-g="12 md:8">
+													<section aria-labelledby="guidance-programmes">
+															<h2 id="guidance-programmes" class="mt--0">Guidance by programme</h2>
+															<ul class="grid">
+																	<li data-g="12 sm:6">
+																			<h3 class="h5 mt--0 mb--c"><a href="/guidance/published?type=apg,csg,cg,mpg,ph,sg,sc"> NICE guidelines </a></h3>
+																			<p class="mt--0">Review the evidence across broad health and social care topics. Includes <a href="/guidance/published?type=cg">clinical&nbsp;guidelines</a>.</p>
+																	</li>
+																	<li data-g="12 sm:6">
+																			<h3 class="h5 mt--0 mb--c"><a href="/guidance/published?type=ta"> Technology appraisal guidance </a></h3>
+																			<p class="mt--0">Review clinical and cost effectiveness of new&nbsp;treatments.</p>
+																	</li>
+																	<li data-g="12 sm:6">
+																			<h3 class="h5 mt--0 mb--c"><a href="/guidance/published?type=dg"> Diagnostics guidance </a></h3>
+																			<p class="mt--0">Review new diagnostic technologies for adoption in the&nbsp;NHS.</p>
+																	</li>
+																	<li data-g="12 sm:6" class="mb--c">
+																			<h3 class="h5 mt--0 mb--c"><a href="/guidance/published?type=hst"> Highly specialised technologies guidance </a></h3>
+																			<p class="mt--0">Review clinical and cost effectiveness of specialised&nbsp;treatments.</p>
+																	</li>
+																	<li data-g="12 sm:6" class="mb--c">
+																			<h3 class="h5 mt--0 mb--c"><a href="/guidance/published?type=ipg"> Interventional procedures guidance </a></h3>
+																			<p class="mt--0"><span>Review the efficacy and safety of&nbsp;procedures</span></p>
+																	</li>
+																	<li data-g="12 sm:6" class="mb--c">
+																			<h3 class="h5 mt--0 mb--c"><a href="/guidance/published?type=mtg"> Medical technologies guidance </a></h3>
+																			<p class="mt--0">Review new medical devices for adoption in the&nbsp;NHS.</p>
+																	</li>
+															</ul>
+													</section>
+													<section aria-labelledby="in-development-updated">
+															<h2 id="in-development-updated" class="mt--0">Products being developed or&nbsp;updated</h2>
+															<ul class="grid">
+																	<li data-g="12 xs:6 sm:4">
+																			<h3 class="h5 mt--0 mb--c"><a href="/guidance/inconsultation"> In consultation </a></h3>
+																			<p class="mt--0">Guidance and quality standards open for&nbsp;consultation.</p>
+																	</li>
+																	<li data-g="12 xs:6 sm:4">
+																			<h3 class="h5 mt--0 mb--c"><a href="/guidance/indevelopment"> In development </a></h3>
+																			<p class="mt--0">Guidance, quality standards and advice being&nbsp;developed.</p>
+																	</li>
+																	<li data-g="12 xs:6 sm:4">
+																			<h3 class="h5 mt--0 mb--c"><a href="/guidance/proposed"> Proposed </a></h3>
+																			<p class="mt--0"><span>Guidance and quality standards that have been proposed for development.</span></p>
+																	</li>
+															</ul>
+													</section>
+													<hr class="mt--d" />
+													<h2>We also produce:</h2>
+													<section aria-labelledby="quality-standards">
+															<h3 id="quality-standards" class="mt--0"><a href="/guidance/published?type=qs">Quality standards</a></h3>
+															<p>Set out priority areas for quality improvement in health and social care.</p>
+													</section>
+													<section aria-labelledby="advice">
+															<h3 id="advice" class="mt--0"><a href="/guidance/published?type=esmpb,esnm,esuom,ktt,lgb,mib">Advice</a></h3>
+															<p>A range of products that critically assess and summarise the latest evidence.</p>
+															<ul class="grid">
+																	<li data-g="12 xs:6 sm:4">
+																			<h3 class="h5 mt--0 mb--c"><a href="/guidance/published?type=es"> Evidence summaries </a></h3>
+																			<p class="mt--0">Review the best available evidence for selected medicines. Includes <a href="/guidance/published?type=apa">antimicrobial&nbsp;prescribing</a>.</p>
+																	</li>
+																	<li data-g="12 xs:6 sm:4">
+																			<h3 class="h5 mt--0 mb--c"><a href="/guidance/published?type=mib"> Medtech innovation briefings </a></h3>
+																			<p class="mt--0">Review the evidence and likely costs of medical devices and&nbsp;technologies.</p>
+																	</li>
+																	<li data-g="12 xs:6 sm:4">
+																			<h3 class="h5 mt--0 mb--c"><a href="/guidance/published?type=ktt"> Key therapeutic topics </a></h3>
+																			<p class="mt--0">Evidence summaries to support medicines&nbsp;optimisation.</p>
+																	</li>
+															</ul>
+													</section>
+											</div>
+									</main>
+							</div>
+
+					</div>
+			</div>
+	</div>
+</div>
+
+
+
+<script>// <![CDATA[
+var cpy = document.getElementsByClassName("legal-copyright")[0];
+if(cpy)
+	cpy.innerHTML = cpy.innerHTML.replace("[year]", new Date().getFullYear());
+// ]]></script>
+    </div>
+  </div></div>
+    <!--[if lt IE 9]>
+<script src="//cdnjs.cloudflare.com/ajax/libs/respond.js/1.4.2/respond.min.js" type="text/javascript"></script>
+<![endif]-->
+<script src="//cdn.nice.org.uk/V2/Scripts/twitter.bootstrap.min.js" type="text/javascript"></script>
+<script src="//cdn.nice.org.uk/V2/Scripts/NICE.bootstrap.min.js" type="text/javascript"></script>
+<script type="text/javascript"></script>
+<script src="https://www.nice.org.uk/Modules/Orchard.Resources/scripts/history.min.js" type="text/javascript"></script>
+<script src="//cdn.nice.org.uk/V3/Scripts/nice/NICE.EventTracking.js" type="text/javascript"></script>
+<script src="https://www.nice.org.uk/Themes/NICE.Bootstrap/scripts/niceorg/NICE.TopScroll.js" type="text/javascript"></script>
+<script src="https://www.nice.org.uk/Themes/NICE.Bootstrap/scripts/foot.combined-v1.10.7695.0.js" type="text/javascript"></script>
+
+
+<script type="text/javascript">
+		$(document).ajaxSend(function (event, jqxhr, settings) {
+				if (settings.url.indexOf("?") >= 0) {
+						settings.url = settings.url + "&ajax=ajax";
+				} else {
+						settings.url = settings.url + "?ajax=ajax";
+				}
+		})
+</script>
+<script type="text/javascript">
+		var is_touch_device = 'ontouchstart' in document.documentElement;
+		if (is_touch_device) {
+				$('body').addClass('touch-screen-device');
+		} else {
+				$('body').addClass('non-touch-screen-device');
+		}
+</script>

--- a/examples/examples.js
+++ b/examples/examples.js
@@ -204,6 +204,20 @@ const noAuthNoSearchConfig = {
 	}
 };
 
+const identityPopupConfig = {
+	filename: "identity-popup",
+	title: "Identity Popup signin",
+	global_nav_config: {
+		header: {
+			auth: {
+				provider: "idam",
+				mode: "popup"
+			},
+			search: false
+		}
+	}
+};
+
 module.exports = [
 	pathwaysConfig,
 	guidanceConfig,
@@ -216,5 +230,6 @@ module.exports = [
 	journalsConfig,
 	identityAdminLoggedOutConfig,
 	identityAdminLoggedInConfig,
-	noAuthNoSearchConfig
+	noAuthNoSearchConfig,
+	identityPopupConfig
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,26 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@auth0/auth0-spa-js": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-1.6.3.tgz",
+			"integrity": "sha512-jbK6qrcy3N8bAltP/sEdv9vo0eML9LneAESB05K/MPCwZVUJN9hu+y42DxfI7kH6dnVNyUbJohgpimv+eNonlQ==",
+			"requires": {
+				"browser-tabs-lock": "^1.2.1",
+				"core-js": "^3.2.1",
+				"es-cookie": "^1.2.0",
+				"fast-text-encoding": "^1.0.0",
+				"promise-polyfill": "^8.1.3",
+				"unfetch": "^4.1.0"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "3.6.4",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+					"integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+				}
+			}
+		},
 		"@babel/cli": {
 			"version": "7.7.0",
 			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.7.0.tgz",
@@ -2669,6 +2689,11 @@
 				}
 			}
 		},
+		"browser-tabs-lock": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/browser-tabs-lock/-/browser-tabs-lock-1.2.6.tgz",
+			"integrity": "sha512-+FUo97nnOix/nQo+j4HyCO47bsJtfx1EFhj1rghqYx7N0MQ8D34aoP4eJGrMtN0D18s2OAGpbPqo/0ONGxDLiA=="
+		},
 		"browserify-aes": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -4665,6 +4690,11 @@
 				"object-keys": "^1.0.12"
 			}
 		},
+		"es-cookie": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/es-cookie/-/es-cookie-1.3.2.tgz",
+			"integrity": "sha512-UTlYYhXGLOy05P/vKVT2Ui7WtC7NiRzGtJyAKKn32g5Gvcjn7KAClLPWlipCtxIus934dFg9o9jXiBL0nP+t9Q=="
+		},
 		"es-to-primitive": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
@@ -5377,6 +5407,11 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
+		"fast-text-encoding": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.0.tgz",
+			"integrity": "sha512-R9bHCvweUxxwkDwhjav5vxpFvdPGlVngtqmx4pIZfSUhM/Q4NiIUHB456BAf+Q1Nwu3HEZYONtu+Rya+af4jiQ=="
+		},
 		"faye-websocket": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
@@ -5640,7 +5675,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -5661,12 +5697,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -5681,17 +5719,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -5808,7 +5849,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -5820,6 +5862,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -5834,6 +5877,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -5841,12 +5885,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -5865,6 +5911,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -5945,7 +5992,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -5957,6 +6005,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -6042,7 +6091,8 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -6078,6 +6128,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -6097,6 +6148,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -6140,12 +6192,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -10419,8 +10473,7 @@
 		"promise-polyfill": {
 			"version": "8.1.3",
 			"resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
-			"integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==",
-			"dev": true
+			"integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g=="
 		},
 		"prompts": {
 			"version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "./types.d.ts",
   "scripts": {
     "// LOCAL DEV": "",
-    "start": "cross-env NODE_ENV=development webpack-dev-server --hot --inline",
+    "start": "cross-env NODE_ENV=development webpack-dev-server --https --hot --inline",
     "start:nohot": "cross-env HOT=false NODE_ENV=development webpack-dev-server",
     "// PRODUCTION BUILDS": "",
     "build": "cross-env NODE_ENV=production webpack --config webpack.config.prod.js",
@@ -109,6 +109,7 @@
     "webpack-merge": "^4.2.2"
   },
   "dependencies": {
+    "@auth0/auth0-spa-js": "^1.6.3",
     "@babel/runtime": "^7.7.2",
     "@nice-digital/browserslist-config": "^1.0.0",
     "@nice-digital/icons": "^2.1.1",

--- a/src/Header/Header.jsx
+++ b/src/Header/Header.jsx
@@ -193,6 +193,7 @@ export class Header extends Component {
 						useIdamPopupLogin={this.state.useIdamPopupLogin}
 						onIdAMLoginClick={this.handleIdamLogin}
 						onIdAMLogoutClick={this.handleIdamLogout}
+						isAuthenticated={this.state.isLoggedIn}
 						accountsLinks={
 							this.state.accountsData && this.state.accountsData.links
 						}

--- a/src/Header/Header.jsx
+++ b/src/Header/Header.jsx
@@ -146,7 +146,7 @@ Header.propTypes = {
 	enabled: PropTypes.bool,
 	search: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
 	cookie: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
-	auth: PropTypes.object,
+	auth: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
 	onNavigating: PropTypes.oneOfType([PropTypes.func, PropTypes.string])
 };
 

--- a/src/Header/Nav/Nav.jsx
+++ b/src/Header/Nav/Nav.jsx
@@ -192,5 +192,8 @@ Nav.propTypes = {
 	service: PropTypes.string,
 	isExpanded: PropTypes.bool,
 	accountsLinks: PropTypes.object,
-	onNavigating: PropTypes.oneOfType([PropTypes.func, PropTypes.string])
+	onNavigating: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+	useIdamPopupLogin: PropTypes.bool,
+	onIdAMLoginClick: PropTypes.func,
+	onIdAMLogoutClick: PropTypes.func
 };

--- a/src/Header/Nav/Nav.jsx
+++ b/src/Header/Nav/Nav.jsx
@@ -183,6 +183,36 @@ export default class Nav extends Component {
 						</div>
 					</nav>
 				)}
+				{this.props.useIdamPopupLogin && (
+					<nav
+						aria-label="My account"
+						className={classnames(styles.nav, styles.myAccount)}
+					>
+						<div className={styles.menuWrapper}>
+							<ul className={styles.menuList} role="menu">
+								<li key="idamSigninOrout" role="presentation">
+									{this.props.isAuthenticated ? (
+										<button
+											role="menuitem"
+											className={styles.link}
+											onClick={this.props.onIdAMLogoutClick}
+										>
+											Sign out
+										</button>
+									) : (
+										<button
+											role="menuitem"
+											className={styles.link}
+											onClick={this.props.onIdAMLoginClick}
+										>
+											Sign in
+										</button>
+									)}
+								</li>
+							</ul>
+						</div>
+					</nav>
+				)}
 			</div>
 		);
 	}
@@ -195,5 +225,6 @@ Nav.propTypes = {
 	onNavigating: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
 	useIdamPopupLogin: PropTypes.bool,
 	onIdAMLoginClick: PropTypes.func,
-	onIdAMLogoutClick: PropTypes.func
+	onIdAMLogoutClick: PropTypes.func,
+	isAuthenticated: PropTypes.bool
 };

--- a/src/Header/Nav/Nav.module.scss
+++ b/src/Header/Nav/Nav.module.scss
@@ -54,8 +54,10 @@
   }
 }
 
-a.link {
+a.link,
+button.link {
   //qualified this with a to add specificity to avoid overrides from application css (NW-1253)
+  background-color: transparent;
   border: rem($nds-spacing-x-small) solid $colour-nav-background;
   border-bottom-width: 0;
   border-top-width: 0;

--- a/src/Header/Search/Autocomplete/Autocomplete.test.jsx
+++ b/src/Header/Search/Autocomplete/Autocomplete.test.jsx
@@ -112,7 +112,7 @@ describe("Autocomplete", () => {
 
 		it("should not load suggestions within the reate limit threshold", () => {
 			jest.useFakeTimers();
-			const callback = () => {};
+			//const callback = () => {};
 			const wrapper = shallow(
 				<Autocomplete {...defaultProps} source="/url" query="test" />
 			);


### PR DESCRIPTION
**not for merging**

this spike implements logging into to idam directly in global-nav.

an extra "mode" parameter has been added to the "auth" parameter object.
when auth.provider is set to "idam" and mode is set to "popup", then global-nav will support logging into idam via a popup.

when mode is set to "inline" then global-nav will output username and password input boxes and support signing in directly (currently not implemented)

when mode is set to "links" or unset, then the previous method - i.e. full page redirect will be used.


but note: **not for merging** (yet)
