### PR TITLE
GN-43 Updating the coronavirus banner

### DIFF
--- a/src/Header/CoronaMessage/CoronaMessage.jsx
+++ b/src/Header/CoronaMessage/CoronaMessage.jsx
@@ -10,7 +10,7 @@ const CoronaMessage = () => (
 				For information on how NICE is supporting the NHS and social care, view
 				our new{" "}
 				<a href="https://www.nice.org.uk/coronavirus">
-					rapid guidelines and evidence&nbsp;reviews
+					rapid guidelines and evidence&nbsp;summaries
 				</a>
 				. Learn about the{" "}
 				<a href="https://gov.uk/coronavirus">

--- a/src/Header/CoronaMessage/__snapshots__/CoronaMessage.test.jsx.snap
+++ b/src/Header/CoronaMessage/__snapshots__/CoronaMessage.test.jsx.snap
@@ -16,7 +16,7 @@ exports[`CoronaMessage Matches snapshot 1`] = `
       <a
         href="https://www.nice.org.uk/coronavirus"
       >
-        rapid guidelines and evidence reviews
+        rapid guidelines and evidence summaries
       </a>
       . Learn about the
        


### PR DESCRIPTION
https://nicedigital.atlassian.net/browse/GN-43

Updates the phrase "evidence reviews" to "evidence summaries"