### PR TITLE
GN-42 Add cookie dismiss to the COVID banner

### DIFF
--- a/src/Header/CoronaMessage/CoronaMessage.jsx
+++ b/src/Header/CoronaMessage/CoronaMessage.jsx
@@ -1,25 +1,99 @@
-import React from "react";
+import React, { Component } from "react";
+import Cookies from "js-cookie";
 
 import styles from "./CoronaMessage.module.scss";
 
-const CoronaMessage = () => (
-	<aside className={styles.wrapper}>
-		<div className={styles.container}>
-			<h2>Coronavirus (COVID-19)</h2>
-			<p>
-				For information on how NICE is supporting the NHS and social care, view
-				our new{" "}
-				<a href="https://www.nice.org.uk/coronavirus">
-					rapid guidelines and evidence&nbsp;reviews
-				</a>
-				. Learn about the{" "}
-				<a href="https://gov.uk/coronavirus">
-					government response to coronavirus on&nbsp;GOV.UK
-				</a>
-				.
-			</p>
-		</div>
-	</aside>
-);
+export const CookieName = "seen_corona_message";
+
+// Increment this and release a new version to make the message reappear for users who had previously dismissed
+export const CookieMessageVersion = 1;
+
+class CoronaMessage extends Component {
+	constructor(props) {
+		super(props);
+
+		this.state = {
+			hasSeenPreviousVersion: false,
+			isClosed: true,
+			canUseDOM: false
+		};
+
+		this.handleClick = this.handleClick.bind(this);
+	}
+
+	componentDidMount() {
+		this.setState({
+			canUseDOM: true
+		});
+
+		const cookieValue = Cookies.getJSON(CookieName);
+
+		if (!cookieValue) {
+			Cookies.remove(CookieName);
+			this.setState({
+				hasSeenPreviousVersion: false,
+				isClosed: false // Hide by default on the assumption that if JS doesn't work then we won't be setting cookies anyway
+			});
+		} else {
+			const seenVersion = cookieValue;
+
+			this.setState({
+				hasSeenPreviousVersion: seenVersion < CookieMessageVersion,
+				isClosed: seenVersion === CookieMessageVersion
+			});
+		}
+	}
+
+	getCookieDomain(host) {
+		return ~host.indexOf("nice.org.uk") ? "nice.org.uk" : host;
+	}
+
+	handleClick() {
+		const cookieOptions = {
+			secure: false,
+			expires: 365 // In days
+		};
+
+		if (window.location.hostname !== "localhost") {
+			cookieOptions.domain = this.getCookieDomain(window.location.hostname);
+		}
+
+		Cookies.set(CookieName, CookieMessageVersion, cookieOptions);
+
+		this.setState({
+			isClosed: true
+		});
+	}
+
+	render() {
+		if (this.state.isClosed) return null;
+		return (
+			<aside className={styles.wrapper}>
+				<div className={styles.container}>
+					<h2>Coronavirus (COVID-19)</h2>
+					<p>
+						For information on how NICE is supporting the NHS and social care,
+						view our new{" "}
+						<a href="https://www.nice.org.uk/coronavirus">
+							rapid guidelines and evidence&nbsp;reviews
+						</a>
+						. Learn about the{" "}
+						<a href="https://gov.uk/coronavirus">
+							government response to coronavirus on&nbsp;GOV.UK
+						</a>
+						.
+					</p>
+					<button
+						className={styles.button}
+						type="button"
+						onClick={this.handleClick}
+					>
+						Close
+					</button>
+				</div>
+			</aside>
+		);
+	}
+}
 
 export default CoronaMessage;

--- a/src/Header/CoronaMessage/CoronaMessage.module.scss
+++ b/src/Header/CoronaMessage/CoronaMessage.module.scss
@@ -47,3 +47,27 @@
 .lastP {
   margin-bottom: 0;
 }
+
+.button {
+  appearance: none;
+  background: $nds-colour-btn-primary;
+  border: em(1) solid $nds-colour-btn-primary-text;
+  border-radius: 0;
+  color: $nds-colour-btn-primary-text;
+  cursor: pointer;
+  display: inline-block;
+  margin: 0;
+  padding: em($nds-spacing-small $nds-spacing-medium);
+  position: relative;
+  text-align: left;
+  text-decoration: none !important; // sass-lint:disable-line no-important
+  vertical-align: top;
+  white-space: nowrap;
+
+  &:focus {
+    background: $nds-colour-btn-primary;
+    border-color: $nds-colour-focus-inverse;
+    color: $nds-colour-btn-primary-text;
+    outline: 3px solid $nds-colour-focus;
+  }
+}

--- a/src/Header/CoronaMessage/CoronaMessage.test.jsx
+++ b/src/Header/CoronaMessage/CoronaMessage.test.jsx
@@ -1,17 +1,118 @@
 import React from "react";
-import CoronaMessage from "./CoronaMessage";
-import { shallow } from "enzyme";
+import Cookies from "js-cookie";
 import toJson from "enzyme-to-json";
+import CoronaMessage, {
+	CookieMessageVersion,
+	CookieName
+} from "./CoronaMessage";
+import { shallow } from "enzyme";
 
 describe("CoronaMessage", () => {
+	const oldCookie = document.cookie;
+
+	beforeEach(() => {
+		// Reset overridden cookie property
+		document.cookie = oldCookie;
+		Cookies.set(CookieName, null);
+	});
+
 	it("Renders without crashing", () => {
 		const wrapper = shallow(<CoronaMessage />);
+
 		expect(wrapper).toHaveLength(1);
 	});
 
-	it("Matches snapshot", () => {
+	it("Doesn't render by default/on the server", () => {
+		const wrapper = shallow(<CoronaMessage />, {
+			disableLifecycleMethods: true
+		});
+
+		expect(wrapper.isEmptyRender()).toBe(true);
+	});
+
+	it("Renders after rehydration on the client", () => {
 		const wrapper = shallow(<CoronaMessage />);
 
+		wrapper.update();
+
+		expect(wrapper.isEmptyRender()).toBe(false);
+	});
+
+	it("Matches snapshot for new visitor", () => {
+		const wrapper = shallow(<CoronaMessage />);
+
+		wrapper.update();
+
 		expect(toJson(wrapper)).toMatchSnapshot();
+	});
+
+	it("Hides cookie message when seen correct message version", () => {
+		Cookies.set(CookieName, CookieMessageVersion);
+
+		const wrapper = shallow(<CoronaMessage />);
+
+		wrapper.update();
+
+		expect(wrapper.isEmptyRender()).toBe(true);
+	});
+
+	it("Triggers click handler on close button click", () => {
+		const handleClick = jest.spyOn(CoronaMessage.prototype, "handleClick");
+		const wrapper = shallow(<CoronaMessage />);
+
+		wrapper.update();
+
+		wrapper
+			.find("button")
+			.at(0)
+			.simulate("click");
+
+		expect(handleClick).toHaveBeenCalledTimes(1);
+	});
+
+	it("Hides message on close button click", () => {
+		const wrapper = shallow(<CoronaMessage />);
+
+		wrapper.update();
+
+		wrapper
+			.find("button")
+			.at(0)
+			.simulate("click");
+
+		expect(wrapper.isEmptyRender()).toBe(true);
+	});
+
+	it("Stores cookie on evidence domain on button click", () => {
+		const oldLocation = global.window.location;
+		delete global.window.location;
+		global.window.location = new URL("https://www.evidence.nhs.uk/");
+
+		const cookieSet = jest.fn();
+
+		Object.defineProperty(document, "cookie", {
+			get: jest.fn().mockImplementation(() => null),
+			set: cookieSet,
+			configurable: true
+		});
+
+		const wrapper = shallow(<CoronaMessage />);
+
+		wrapper.update();
+
+		wrapper
+			.find("button")
+			.at(0)
+			.simulate("click");
+
+		const date = new Date();
+		date.setDate(date.getDate() + 365);
+
+		expect(cookieSet.mock.calls[1][0]).toEqual(
+			`${CookieName}=${CookieMessageVersion}; path=/; expires=${date.toUTCString()}; domain=www.evidence.nhs.uk`
+		);
+
+		// Tidy up
+		global.window.location = oldLocation;
 	});
 });

--- a/src/Header/CoronaMessage/__snapshots__/CoronaMessage.test.jsx.snap
+++ b/src/Header/CoronaMessage/__snapshots__/CoronaMessage.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CoronaMessage Matches snapshot 1`] = `
+exports[`CoronaMessage Matches snapshot for new visitor 1`] = `
 <aside
   className="wrapper"
 >
@@ -27,6 +27,13 @@ exports[`CoronaMessage Matches snapshot 1`] = `
       </a>
       .
     </p>
+    <button
+      className="button"
+      onClick={[Function]}
+      type="button"
+    >
+      Close
+    </button>
   </div>
 </aside>
 `;

--- a/src/Header/__snapshots__/Header.test.jsx.snap
+++ b/src/Header/__snapshots__/Header.test.jsx.snap
@@ -66,7 +66,7 @@ exports[`Header Matches snapshot 1`] = `
     onNavigating="onNavigatingHandler"
     service={null}
   />
-  <bound CoronaMessage />
+  <CoronaMessage />
   <OldIEMessage />
   <div
     aria-label="Start of content"


### PR DESCRIPTION
https://nicedigital.atlassian.net/browse/GN-42

@chunter @ediblecode Corona message interfering with pathways rendering. Have added ability for message to be dismissed with cookies in the same way that the cookie banner is. This is half the story - pathways will need to reload / redraw after dismissal as the dimension are set on page render.