### PR TITLE
Fix SASS division deprecation warnings

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -15,6 +15,7 @@
 		"number-leading-zero": "always",
 		"declaration-empty-line-before": "never",
 		"at-rule-empty-line-before": null,
+		"no-invalid-position-at-import-rule": null,
 		"scss/at-else-closing-brace-newline-after": "always-last-in-chain",
 		"scss/at-else-closing-brace-space-after": "always-intermediate",
 		"scss/at-else-empty-line-before": "never",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1929,13 +1929,20 @@
       }
     },
     "@nice-digital/nds-core": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@nice-digital/nds-core/-/nds-core-1.2.12.tgz",
-      "integrity": "sha512-3n+Yh9siTMteyBQk0SvL+Pl+hYtYS4FMEkyWwQvjjrTyuCVp614eSnZk119wj8MprFm2wr43jaCWYqhbuDmm7Q==",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/@nice-digital/nds-core/-/nds-core-1.2.13.tgz",
+      "integrity": "sha512-IuiZ8WBRdArkO8OlNLJaEzKro+SIQ+xzcEbSYIMSCW8Pbg1EkONtLgcsJMuD8q22SYyLbq3Bxhro2HvxGFaN0Q==",
       "requires": {
         "@nice-digital/icons": "^2.2.7",
         "prop-types": "^15.7.2",
-        "sass-mq": "^5.0.0"
+        "sass-mq": "^6.0.0"
+      },
+      "dependencies": {
+        "sass-mq": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/sass-mq/-/sass-mq-6.0.0.tgz",
+          "integrity": "sha512-h4VicIy8lszFlqqggqLIFGt/9wS5fHLPoTXHRjC8Vw6UsA4s4JtDvEeypXbbECfgY336mXyc/cdpbRacH0UzGA=="
+        }
       }
     },
     "@nicolo-ribaudo/chokidar-2": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@babel/runtime": "^7.16.7",
     "@nice-digital/icons": "^2.2.7",
     "@nice-digital/nds-container": "^1.0.8",
-    "@nice-digital/nds-core": "^1.2.11",
+    "@nice-digital/nds-core": "^1.2.13",
     "@use-it/event-listener": "^0.1.7",
     "accessible-autocomplete": "^2.0.3",
     "classnames": "^2.3.1",

--- a/src/Footer/Footer.module.scss
+++ b/src/Footer/Footer.module.scss
@@ -1,3 +1,4 @@
+@use 'sass:math';
 @import '~@nice-digital/nds-core/scss/core';
 @import 'footer-settings';
 @import '../Common.module.scss';
@@ -48,7 +49,7 @@
 
 .logo {
   $logo-width: 80px;
-  $logo-aspect-ratio: 512 / 1410;
+  $logo-aspect-ratio: math.div(512, 1410);
   display: block;
   height: 0;
   margin: rem(0 0 $nds-spacing-large 0);

--- a/src/Footer/Pages/Pages.module.scss
+++ b/src/Footer/Pages/Pages.module.scss
@@ -1,3 +1,4 @@
+@use 'sass:math';
 @import '~@nice-digital/nds-core/scss/core';
 
 .wrapper {
@@ -26,7 +27,7 @@
     float: left;
     margin: 0;
     padding: rem(0 0 0 $nds-spacing-large);
-    width: percentage(2 / 3);
+    width: percentage(math.div(2, 3));
   }
 }
 

--- a/src/Footer/Services/Services.module.scss
+++ b/src/Footer/Services/Services.module.scss
@@ -1,3 +1,4 @@
+@use 'sass:math';
 @import '~@nice-digital/nds-core/scss/core';
 @import '../../Common.module.scss';
 
@@ -19,7 +20,7 @@
   .wrapper {
     border-right: 2px solid $nds-colour-nice-dark-grey;
     float: left;
-    width: percentage(1 / 3);
+    width: percentage(math.div(1, 3));
   }
 }
 

--- a/src/Header/Account/Account.module.scss
+++ b/src/Header/Account/Account.module.scss
@@ -1,3 +1,4 @@
+@use 'sass:math';
 @import '~@nice-digital/nds-core/scss/core';
 @import '../header-settings';
 
@@ -87,9 +88,10 @@
   }
 
   &:after {
-    border-bottom: rem($nds-spacing-small / 1.25) solid $nds-colour-true-white;
-    border-left: rem($nds-spacing-x-small / 1.25) solid transparent;
-    border-right: rem($nds-spacing-x-small / 1.25) solid transparent;
+    border-bottom: rem(math.div($nds-spacing-small, 1.25)) solid
+      $nds-colour-true-white;
+    border-left: rem(math.div($nds-spacing-x-small, 1.25)) solid transparent;
+    border-right: rem(math.div($nds-spacing-x-small, 1.25)) solid transparent;
     bottom: 100%;
     content: '';
     display: block;

--- a/src/Header/Header.module.scss
+++ b/src/Header/Header.module.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import 'header-settings';
 
 .header {
@@ -73,7 +75,7 @@
   flex-grow: 1;
   float: left;
   margin-right: rem($nds-spacing-medium);
-  min-width: percentage(2 / 3);
+  min-width: percentage(math.div(2, 3));
 }
 
 .mobileMenuBtn {


### PR DESCRIPTION
This should (hopefully) be the last required fix to get rid of the deprecation warnings clogging up the console when running BNF and any other project with NDS Core or the global nav as dependencies.

I had to switch off the "no-invalid-position-at-import-rule" stylelint rule because there was a circular error: `@import` and `@use` statements each wanted to appear before the other, so one of them had to go!